### PR TITLE
Add Client Hints headers to `HttpHeaders`

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -45,6 +45,16 @@ public interface HttpHeaders extends Headers {
     String ACCEPT = "Accept";
 
     /**
+     * {@code "Accept-CH"}.
+     */
+    String ACCEPT_CH = "Accept-CH";
+
+    /**
+     * {@code "Accept-CH"}.
+     */
+    String ACCEPT_CH_LIFETIME = "Accept-CH-Lifetime";
+
+    /**
      * {@code "Accept-Charset"}.
      */
     String ACCEPT_CHARSET = "Accept-Charset";
@@ -150,6 +160,11 @@ public interface HttpHeaders extends Headers {
     String CONTENT_DISPOSITION = "Content-Disposition";
 
     /**
+     * {@code "Content-DPR"}.
+     */
+    String CONTENT_DPR = "Content-DPR";
+
+    /**
      * {@code "Content-Encoding"}.
      */
     String CONTENT_ENCODING = "Content-Encoding";
@@ -198,6 +213,26 @@ public interface HttpHeaders extends Headers {
      * {@code "Date"}.
      */
     String DATE = "Date";
+
+    /**
+     * {@code "Device-Memory"}.
+     */
+    String DEVICE_MEMORY = "Device-Memory";
+
+    /**
+     * {@code "Downlink"}.
+     */
+    String DOWNLINK = "Downlink";
+
+    /**
+     * {@code "DPR"}.
+     */
+    String DPR = "DPR";
+
+    /**
+     * {@code "ECT"}.
+     */
+    String ECT = "ECT";
 
     /**
      * {@code "ETag"}.
@@ -305,6 +340,16 @@ public interface HttpHeaders extends Headers {
     String RETRY_AFTER = "Retry-After";
 
     /**
+     * {@code "RTT"}.
+     */
+    String RTT = "RTT";
+
+    /**
+     * {@code "Save-Data"}.
+     */
+    String SAVE_DATA = "Save-Data";
+
+    /**
      * {@code "Sec-WebSocket-Key1"}.
      */
     String SEC_WEBSOCKET_KEY1 = "Sec-WebSocket-Key1";
@@ -395,6 +440,11 @@ public interface HttpHeaders extends Headers {
     String VIA = "Via";
 
     /**
+     * {@code "Viewport-Width"}.
+     */
+    String VIEWPORT_WIDTH = "Viewport-Width";
+
+    /**
      * {@code "Warning"}.
      */
     String WARNING = "Warning";
@@ -413,6 +463,11 @@ public interface HttpHeaders extends Headers {
      * {@code "WebSocket-Protocol"}.
      */
     String WEBSOCKET_PROTOCOL = "WebSocket-Protocol";
+
+    /**
+     * {@code "Width"}.
+     */
+    String WIDTH = "Width";
 
     /**
      * {@code "WWW-Authenticate"}.


### PR DESCRIPTION
Small change to add support for [_Client Hints_](https://developer.mozilla.org/en-US/docs/Glossary/Client_hints) headers to the `HttpHeaders` enumeration in Micronaut's core HTTP layer. This includes response headers sent to indicate hint support ([`Accept-CH`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-CH)) and request headers sent to indicate hint values (like [`DPR`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR), for instance).

This lays the groundwork for PRs downstream to add support for [Client Hints](https://developer.mozilla.org/en-US/docs/Glossary/Client_hints) writ-large, but for now, it's just the headers themselves.

Sources for docs/specs regarding _Client Hints_:
- [MDN: _Client hints_](https://developer.mozilla.org/en-US/docs/Glossary/Client_hints)
  - [`Accept-CH` Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-CH)
  - [`Accept-CH-Lifetime` Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-CH-Lifetime)
  - [`DPR` Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR)
- [Google Web Fundamentals: _Adapting to Users with Client Hints_](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints)
  - [_Device hints_](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints#device_hints)
  - [_Network hints_](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints#network_hints)
- [HTTP Working Group: _HTTP Client Hints_](https://httpwg.org/http-extensions/client-hints.html) (I. Grigorik, Y. Weiss, 2020, both from Google)